### PR TITLE
update readme - pip path issues on windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Plot the Mandelbrot Set only with your command line! (And a bit of python)
 ## Setup
 Install the needed libraries with `pip install -r requirements.txt` and you're good to go! 
 
-Note: On Windows you may need to do `py -m pip install -r requirements.txt` or `py3 -m pip install -r requirements.txt`.
+*Note: On Windows you may need to do `py -m pip install -r requirements.txt` or `py3 -m pip install -r requirements.txt`.*
 
 ## Usage
 Run it as a normal python project. You can control the camera with the following keys:

--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@
 Plot the Mandelbrot Set only with your command line! (And a bit of python)
 
 ## Setup
-Install the needed libraries with `pip install -r requirements.txt` and you're good to go!
+Install the needed libraries with `pip install -r requirements.txt` and you're good to go! 
+Note: On Windows you may need to do `py -m pip install -r requirements.txt` or `py3 -m pip install -r requirements.txt`.
 
 ## Usage
 Run it as a normal python project. You can control the camera with the following keys:

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ Plot the Mandelbrot Set only with your command line! (And a bit of python)
 
 ## Setup
 Install the needed libraries with `pip install -r requirements.txt` and you're good to go! 
+
 Note: On Windows you may need to do `py -m pip install -r requirements.txt` or `py3 -m pip install -r requirements.txt`.
 
 ## Usage


### PR DESCRIPTION
note added mentioning
`py -m pip install -r requirements.txt` or `py3 -m pip install -r requirements.txt`
as pip isnt always added to path on windows